### PR TITLE
Fix/remote signing

### DIFF
--- a/privval/signer_requestHandler.go
+++ b/privval/signer_requestHandler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cometbft/cometbft/crypto"
 	cryptoenc "github.com/cometbft/cometbft/crypto/encoding"
 	cryptoproto "github.com/cometbft/cometbft/proto/tendermint/crypto"
+	oracleproto "github.com/cometbft/cometbft/proto/tendermint/oracle"
 	privvalproto "github.com/cometbft/cometbft/proto/tendermint/privval"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cometbft/cometbft/types"
@@ -63,6 +64,17 @@ func DefaultValidationRequestHandler(
 				Vote: cmtproto.Vote{}, Error: &privvalproto.RemoteSignerError{Code: 0, Description: err.Error()}})
 		} else {
 			res = mustWrapMsg(&privvalproto.SignedVoteResponse{Vote: *vote, Error: nil})
+		}
+
+	case *privvalproto.Message_SignOracleVoteRequest:
+		vote := r.SignOracleVoteRequest.Vote
+
+		err = privVal.SignOracleVote(chainID, vote)
+		if err != nil {
+			res = mustWrapMsg(&privvalproto.SignedOracleVoteResponse{
+				Vote: oracleproto.GossipedVotes{}, Error: &privvalproto.RemoteSignerError{Code: 0, Description: err.Error()}})
+		} else {
+			res = mustWrapMsg(&privvalproto.SignedOracleVoteResponse{Vote: *vote, Error: nil})
 		}
 
 	case *privvalproto.Message_SignProposalRequest:

--- a/privval/signer_requestHandler.go
+++ b/privval/signer_requestHandler.go
@@ -69,7 +69,7 @@ func DefaultValidationRequestHandler(
 	case *privvalproto.Message_SignOracleVoteRequest:
 		vote := r.SignOracleVoteRequest.Vote
 
-		err = privVal.SignOracleVote(chainID, vote)
+		err = privVal.SignOracleVote("", vote)
 		if err != nil {
 			res = mustWrapMsg(&privvalproto.SignedOracleVoteResponse{
 				Vote: oracleproto.GossipedVotes{}, Error: &privvalproto.RemoteSignerError{Code: 0, Description: err.Error()}})


### PR DESCRIPTION
- add missing `signOracleVote` route handler for remote signing server
- add testcases to confirm that signing and verifying of sigs with filePv and remote signing client are identical and deterministic